### PR TITLE
Fix/odw 1165 schema change folder

### DIFF
--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -1406,7 +1406,7 @@
       "Expected_Within_Weekdays": 1,
       "Standardised_Path": "NSIP",
       "Standardised_Table_Name": "folder",
-      "Standardised_Table_Definition": "standardised_table_definitions/Horizon/DocumentMetaData.json",
+      "Standardised_Table_Definition": "standardised_table_definitions/Horizon/Folder.json",
       "Harmonised_Table_Name": "folder",
       "Harmonised_Incremental_Key": "HorizonFolderID",
       "Entity_Primary_Key": "ID",

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -1409,15 +1409,7 @@
       "Standardised_Table_Definition": "standardised_table_definitions/Horizon/Folder.json",
       "Harmonised_Table_Name": "folder",
       "Harmonised_Incremental_Key": "HorizonFolderID",
-      "Entity_Primary_Key": "ID",
-      "Std_To_Hrm_Mapping": {
-        "ID": "id",
-        "CaseReference": "caseReference",
-        "DisplayNameEnglish": "displayNameEnglish",
-        "DisplayNameWelsh": "displayNameWelsh",
-        "ParentFolderID": "parentFolderId",
-        "CaseStage": "caseStage"
-      }
+      "Entity_Primary_Key": "ID"
     },
     {
       "Source_ID": 118,


### PR DESCRIPTION
Removed mapping for folder config as it's not needed and was causing issues loading the harmonised table. Removing this seems to resolve the issue and the table is loaded as expected.