### PR TITLE
Adding originalFilename column to DocumentMetaData.json

### DIFF
--- a/data-lake/harmonised_table_definitions/document_meta_data.json
+++ b/data-lake/harmonised_table_definitions/document_meta_data.json
@@ -44,6 +44,12 @@
         },
         {
             "metadata": {},
+            "name": "OriginalFilename",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
             "name": "DataSize",
             "type": "string",
             "nullable": true

--- a/data-lake/standardised_table_definitions/Horizon/DocumentMetaData.json
+++ b/data-lake/standardised_table_definitions/Horizon/DocumentMetaData.json
@@ -39,6 +39,7 @@
     },
     { "metadata": {}, "name": "version", "type": "string", "nullable": true },
     { "metadata": {}, "name": "name", "type": "string", "nullable": true },
+    { "metadata": {}, "name": "originalFilename", "type": "string", "nullable": true },
     { "metadata": {}, "name": "dataSize", "type": "string", "nullable": true },
     {
       "metadata": {},


### PR DESCRIPTION
Adds the missing originalFilename column to the standardised schema definition (DocumentMetaData.json) to align with recent pipeline and mapping updates. This ensures the column is correctly ingested and reflected in Test and Prod after release.