### PR TITLE
Updated missing Horizon view and schemas indentation

### DIFF
--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -376,7 +376,10 @@
     },
     {
       "Source_ID": 35,
+      "Load_Enable_status": "True",
       "Source_Folder": "Horizon",
+      "Horizon_Table_Name": "Horizon_vw_BIS_AppealsAdditonalData",
+      "Incremental": false,
       "Source_Frequency_Folder": "",
       "Source_Filename_Format": "AppealsAdditionalData.csv",
       "Source_Filename_Start": "AppealsAdditionalData",
@@ -632,7 +635,10 @@
     },
     {
       "Source_ID": 58,
+      "Load_Enable_status": "True",
       "Source_Folder": "Horizon",
+      "Horizon_Table_Name": "Horizon_vw_BIS_CaseDates",
+      "Incremental": false,
       "Source_Frequency_Folder": "",
       "Source_Filename_Format": "CaseDates.csv",
       "Source_Filename_Start": "CaseDates",
@@ -643,7 +649,10 @@
     },
     {
       "Source_ID": 59,
+      "Load_Enable_status": "True",
       "Source_Folder": "Horizon",
+      "Horizon_Table_Name": "Horizon_vw_BIS_CaseInfo",
+      "Incremental": false,
       "Source_Frequency_Folder": "",
       "Source_Filename_Format": "CaseInfo.csv",
       "Source_Filename_Start": "CaseInfo",
@@ -746,7 +755,10 @@
     },
     {
       "Source_ID": 68,
+      "Load_Enable_status": "True",
       "Source_Folder": "Horizon",
+      "Horizon_Table_Name": "Horizon_vw_BIS_SpecialistCaseDates",
+      "Incremental": false,
       "Source_Frequency_Folder": "",
       "Source_Filename_Format": "SpecialistCaseDates.csv",
       "Source_Filename_Start": "SpecialistCaseDates",

--- a/data-lake/standardised_table_definitions/Horizon/CaseDates.json
+++ b/data-lake/standardised_table_definitions/Horizon/CaseDates.json
@@ -1,1 +1,40 @@
-{"fields": [{"metadata": {}, "name": "ingested_datetime", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_from", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_to", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "appealrefnumber", "type": "string", "nullable": true}, {"metadata": {}, "name": "casereference", "type": "string", "nullable": true}, {"metadata": {}, "name": "validitystatusdate", "type": "string", "nullable": true}]}
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "ingested_datetime",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_from",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_to",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "appealrefnumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "casereference",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "validitystatusdate",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/data-lake/standardised_table_definitions/Horizon/CaseInfo.json
+++ b/data-lake/standardised_table_definitions/Horizon/CaseInfo.json
@@ -1,1 +1,40 @@
-{"fields": [{"metadata": {}, "name": "ingested_datetime", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_from", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_to", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "appealrefnumber", "type": "string", "nullable": true}, {"metadata": {}, "name": "casereference", "type": "string", "nullable": true}, {"metadata": {}, "name": "validity", "type": "string", "nullable": true}]}
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "ingested_datetime",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_from",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_to",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "appealrefnumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "casereference",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "validity",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/data-lake/standardised_table_definitions/Horizon/SpecialistCaseDates.json
+++ b/data-lake/standardised_table_definitions/Horizon/SpecialistCaseDates.json
@@ -1,1 +1,64 @@
-{"fields": [{"metadata": {}, "name": "ingested_datetime", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_from", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_to", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "appealrefnumber", "type": "string", "nullable": true}, {"metadata": {}, "name": "datecostsreportdespatched", "type": "string", "nullable": true}, {"metadata": {}, "name": "datedecisionreportreceivedinpins", "type": "string", "nullable": true}, {"metadata": {}, "name": "datepublicationprocedurecompleted", "type": "string", "nullable": true}, {"metadata": {}, "name": "datereturnedfromreader", "type": "string", "nullable": true}, {"metadata": {}, "name": "datesenttoreader", "type": "string", "nullable": true}, {"metadata": {}, "name": "orderrejectedorreturned", "type": "string", "nullable": true}]}
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "ingested_datetime",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_from",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_to",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "appealrefnumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datecostsreportdespatched",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datedecisionreportreceivedinpins",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datepublicationprocedurecompleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datereturnedfromreader",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datesenttoreader",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "orderrejectedorreturned",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-2307](url)

This PR updates the orchestration file and associated schema definitions for several Horizon sources. The goal is to ensure these tables are ingested into the Raw and Standardised layers correctly and are usable in notebooks

- Added Horizon_Table_Name
- Reformatted JSON schema files for readability