### PR TITLE
Setting DocumentMetadata Incremental value to false

### DIFF
--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -1302,7 +1302,7 @@
       "Load_Enable_status": "True",
       "Source_Folder": "Horizon",
       "Horizon_Table_Name": "Horizon_ODW_vw_DocumentMetadata",
-      "Incremental": true,
+      "Incremental": false,
       "Incremental_Key": "ModifyDate",
       "Source_Frequency_Folder": "",
       "Source_Filename_Format": "DocumentMetaData.csv",


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-2315](url)

Setting the incremental value of DocumentMetadata back to False. Setting it to true made it to pick up only the latest CSV file and not all the 100 of thousands of records. 