### PR TITLE
Adding new table horizon_appeal_s78

### DIFF
--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -227,6 +227,13 @@
             },
             {
                 "database_name": "odw_standardised_db",
+                "table_name": "horizon_appeal_s78",
+                "table_format": "parquet",
+                "table_type": "MANAGED",
+                "table_location": "abfss://odw-standardised@pinsstodwdevuks9h80mb.dfs.core.windows.net/horizon_appeal_s78"
+            },
+            {
+                "database_name": "odw_standardised_db",
                 "table_name": "sap_hr_hist_mig",
                 "table_format": "delta",
                 "table_type": "EXTERNAL",


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-2306](url)
This PR adds a new standardised table for odw_standardised_db.horizon_appeal_s78

The previous name was inconsistent with the documentation this one now aligns with it.
This table will now be the primary Horizon S78 standardised dataset and will be use downstream in Harmonised layer to union Service Bus and Horizon data together. 

The _final table remains in place for now for reference but will be replaced by this new table.