### PR TITLE
Feat/theodw 2727 ingest horizon data for ldc into raw layer and standardised layer

### DIFF
--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -243,7 +243,7 @@
                 "database_name": "odw_standardised_db",
                 "table_name": "horizon_ApplicationMadeUnderSection",
                 "table_format": "parquet",
-                "table_type": "MANAGED",
+                "table_type": "EXTERNAL",
                 "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/horizon_ApplicationMadeUnderSection"
             },            
             {

--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -238,6 +238,13 @@
                 "table_format": "parquet",
                 "table_type": "MANAGED",
                 "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/horizon_notice_dates"
+            },   
+             {
+                "database_name": "odw_standardised_db",
+                "table_name": "horizon_ApplicationMadeUnderSection",
+                "table_format": "parquet",
+                "table_type": "MANAGED",
+                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/horizon_ApplicationMadeUnderSection"
             },            
             {
                 "database_name": "odw_standardised_db",

--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -241,10 +241,10 @@
             },   
              {
                 "database_name": "odw_standardised_db",
-                "table_name": "horizon_ApplicationMadeUnderSection",
+                "table_name": "horizon_application_made_under_section",
                 "table_format": "parquet",
                 "table_type": "EXTERNAL",
-                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/horizon_ApplicationMadeUnderSection"
+                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/horizon_application_made_under_section"
             },            
             {
                 "database_name": "odw_standardised_db",

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2003,6 +2003,21 @@
       "Standardised_Path": "Horizon",
       "Standardised_Table_Name": "horizon_notice_dates",
       "Standardised_Table_Definition": "standardised_table_definitions/Horizon/HorizonNoticeDates.json"
+      },
+      {
+      "Source_ID": 160,
+      "Load_Enable_status": "True",
+      "Source_Folder": "Horizon",
+      "Horizon_Table_Name": "Horizon_ODW_vw_ApplicationMadeUnderActSection",
+      "Incremental": false,
+      "Source_Frequency_Folder": "",
+      "Source_Filename_Format": "horizon_ApplicationMadeUnderSection.csv",
+      "Source_Filename_Start": "horizon_ApplicationMadeUnderSection",
+      "Expected_Within_Weekdays": 1,
+      "Standardised_Path": "Horizon",
+      "Standardised_Table_Name": "horizon_ApplicationMadeUnderSection",
+      "Standardised_Table_Definition": "standardised_table_definitions/Horizon/HorizonApplicationMadeUnderSection.json"
       }
+      
   ]
 }

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2015,7 +2015,7 @@
       "Source_Filename_Start": "horizon_ApplicationMadeUnderSection",
       "Expected_Within_Weekdays": 1,
       "Standardised_Path": "Horizon",
-      "Standardised_Table_Name": "horizon_ApplicationMadeUnderSection",
+      "Standardised_Table_Name": "horizon_application_made_under_section",
       "Standardised_Table_Definition": "standardised_table_definitions/Horizon/HorizonApplicationMadeUnderSection.json"
       }
       

--- a/data-lake/standardised_table_definitions/Horizon/HorizonApplicationMadeUnderSection.json
+++ b/data-lake/standardised_table_definitions/Horizon/HorizonApplicationMadeUnderSection.json
@@ -1,0 +1,40 @@
+{
+    "fields": [
+      {
+        "metadata": {},
+        "name": "ingested_datetime",
+        "type": "timestamp",
+        "nullable": false
+      },
+      {
+        "metadata": {},
+        "name": "expected_from",
+        "type": "timestamp",
+        "nullable": false
+      },
+      {
+        "metadata": {},
+        "name": "expected_to",
+        "type": "timestamp",
+        "nullable": false
+      },
+      {
+        "metadata": {},
+        "name": "caseUniqueId",
+        "type": "integer",
+        "nullable": false
+      },
+      {
+        "metadata": {},
+        "name": "caseNodeId",
+        "type": "integer",
+        "nullable": false
+      },
+      {
+        "metadata": {},
+        "name": "applicationMadeUnderSection",
+        "type": "string",
+        "nullable": true
+      }
+    ]
+  }  


### PR DESCRIPTION
Jira Ticket:
https://pins-ds.atlassian.net/browse/THEODW-2727

This change adds the new Horizon view needed for LDC attributes ingestion for Appeal S78 (Horizon_ODW_vw_ApplicationMadeUnderActSection) and wires it into the orchestration so pln_horizon_to_odw ingests both RAW and Standardised.
It also includes the required prerequisites for later steps (standardised S78 updates, harmonised merge, and curated/MiPINS exposure).
Changes included:

Added Source_ID 160 in orchestration
Added new standardised table definition: HorizonApplicationMadeUnderActSection.json
Registered metadata for: odw_standardised_db.horizon_ApplicationMadeUnderSection