### PR TITLE
THEODW-3079: Add Crown Dev service bus topic

### DIFF
--- a/data-lake/orchestration/orchestration_service_bus.json
+++ b/data-lake/orchestration/orchestration_service_bus.json
@@ -171,6 +171,20 @@
       "processing_enabled": true
     },
     {
+      "entity_name": "application-update",
+      "raw_entity_path": "ServiceBus/application-update/",
+      "standardised_table": "sb_application_update",
+      "sb_harmonised_table": "sb_application_update",
+      "harmonised_table": "application_update",
+      "primary_key": "id",
+      "harmonised_incremental_key": "ApplicationUpdateID",
+      "watermark_column": "message_enqueued_time_utc",
+      "run_raw_to_std": true,
+      "run_std_to_hrm": true,
+      "custom_harmonised_notebooks": [],
+      "processing_enabled": true
+    },
+    {
       "entity_name": "nsip-representation",
       "raw_entity_path": "ServiceBus/nsip-representation/",
       "standardised_table": "sb_nsip_representation",


### PR DESCRIPTION
Enables crown dev application-updated service bus POC end to end using the standard ODW ingestion approach by adding the new topic/subscription configuration in Dev and Test terraform, registering the entity in ODW functions with wake and drain compatibility, and adding orchestration entry in the `orchestration_service_bus.json` so data can flow from raw to standardised and harmonised without bespoke transfrmations.