### PR TITLE
feat: add application-update entity to orchestration service bus config

### DIFF
--- a/data-lake/orchestration/orchestration_service_bus.json
+++ b/data-lake/orchestration/orchestration_service_bus.json
@@ -182,6 +182,21 @@
       "has_horizon_dependency": false
     },
     {
+      "entity_name": "application-update",
+      "raw_entity_path": "ServiceBus/application-update/",
+      "standardised_table": "sb_application_update",
+      "sb_harmonised_table": "sb_application_update",
+      "harmonised_table": "application_update",
+      "primary_key": "id",
+      "harmonised_incremental_key": "ApplicationUpdateID",
+      "watermark_column": "message_enqueued_time_utc",
+      "run_raw_to_std": true,
+      "run_std_to_hrm": true,
+      "custom_harmonised_notebooks": [],
+      "processing_enabled": true,
+      "has_horizon_dependency": false
+    },
+    {
       "entity_name": "nsip-representation",
       "raw_entity_path": "ServiceBus/nsip-representation/",
       "standardised_table": "sb_nsip_representation",


### PR DESCRIPTION
## Summary

- Adds the `application-update` entity definition to `orchestration_service_bus.json`
- This entry was accidentally dropped during the `has_horizon_dependency` migration (PR #175)
- Without this config the pipeline will not pick up the entity, standardised/harmonised tables will not be created, and no processing will occur even if messages are arriving in Service Bus

## Changes

- `entity_name`: `application-update`
- `raw_entity_path`: `ServiceBus/application-update/`
- `primary_key`: `id`
- `harmonised_incremental_key`: `ApplicationUpdateID`
- `has_horizon_dependency`: `false` (Crown Dev entity, no Horizon dependency)

## Test plan

- [ ] Verify pipeline picks up `application-update` messages after deployment
- [ ] Confirm `sb_application_update` standardised and harmonised tables are created