### PR TITLE
fix/disable application-update

### DIFF
--- a/data-lake/orchestration/orchestration_service_bus.json
+++ b/data-lake/orchestration/orchestration_service_bus.json
@@ -193,7 +193,7 @@
       "run_raw_to_std": true,
       "run_std_to_hrm": true,
       "custom_harmonised_notebooks": [],
-      "processing_enabled": true,
+      "processing_enabled": false,
       "has_horizon_dependency": false
     },
     {


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079?focusedCommentId=121787

Temporarily disables application-update in DEV to stop repeated App Insights errors caused by a missing wake subscription. The function is currently trying to access `application-update/Subscriptions/planning-environmental-specialist-odw-wake-sub` in the `pins-sb-back-office-dev-ukw-001` namespace, which is returning `404 MessagingEntityNotFound`. Disabling it prevents further noise and failed lookups until the intended ServiceBus namespace and subscription configuration for application-update is confirmed and correct. 