### PR TITLE
add application to orchestration file

### DIFF
--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -500,6 +500,13 @@
             },
             {
                 "database_name": "odw_standardised_db",
+                "table_name": "sb_application_update",
+                "table_format": "delta",
+                "table_type": "EXTERNAL",
+                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_application_update"
+            },
+            {
+                "database_name": "odw_standardised_db",
                 "table_name": "sb_nsip_representation",
                 "table_format": "delta",
                 "table_type": "EXTERNAL",
@@ -1012,6 +1019,13 @@
                 "table_format": "delta",
                 "table_type": "EXTERNAL",
                 "table_location": "abfss://odw-harmonised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_nsip_project_update"
+            },
+            {
+                "database_name": "odw_harmonised_db",
+                "table_name": "sb_application_update",
+                "table_format": "delta",
+                "table_type": "EXTERNAL",
+                "table_location": "abfss://odw-harmonised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_application_update"
             },
             {
                 "database_name": "odw_harmonised_db",

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2018,6 +2018,19 @@
       "Standardised_Path": "Horizon",
       "Standardised_Table_Name": "horizon_application_made_under_section",
       "Standardised_Table_Definition": "standardised_table_definitions/Horizon/HorizonApplicationMadeUnderSection.json"
+      },
+      {
+      "Source_ID": 161,
+      "Source_Folder": "ServiceBus",
+      "Source_Frequency_Folder": "application-update",
+      "Source_Filename_Format": "application-update.csv",
+      "Source_Filename_Start": "application-update",
+      "Expected_Within_Weekdays": 1,
+      "Standardised_Path": "",
+      "Standardised_Table_Name": "sb_application_update",
+      "Harmonised_Table_Name": "sb_application_update",
+      "Harmonised_Incremental_Key": "ApplicationUpdateID",
+      "Entity_Primary_Key": "id"
       }
       
   ]


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079

`application-update ` was added to the Service Bus orchestration config only, but not to the main orchestration config used by schema-driven table creation. As a result, create_table_from_schema failed when creating the relevant table because no incremental key metadata existed for the entity in `orchestration.json`

Added `application-update` to orchestration.json with the required table creation metadata and table metadata for sb_application_update in the exisiting-tables-metadata.json as part of this PR, sb_application_update metadata entries have been included for both standardised and harmonised with EXTERNAL delta locations.

Validation:
<img width="1647" height="901" alt="image" src="https://github.com/user-attachments/assets/5098e4f1-e9f5-4f5c-b4ac-c0056e194d63" />
