### PR TITLE
add curated processing flag

### DIFF
--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2030,7 +2030,8 @@
       "Standardised_Table_Name": "sb_application_update",
       "Harmonised_Table_Name": "sb_application_update",
       "Harmonised_Incremental_Key": "ApplicationUpdateID",
-      "Entity_Primary_Key": "id"
+      "Entity_Primary_Key": "id",
+      "odw_curated_db_table_status": false
       }
       
   ]

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2031,7 +2031,7 @@
       "Harmonised_Table_Name": "sb_application_update",
       "Harmonised_Incremental_Key": "ApplicationUpdateID",
       "Entity_Primary_Key": "id",
-      "odw_curated_db_table_status": false
+      "odw_curated_table_creation_enabled": false
       }
       
   ]


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3380

Added `odw_curated_db_table_status`: false to the `application-update` entity definition. This flag explicitly marks that no curated table should be created for this entity. No other entity definitions were modified - entities without this flag are unaffected and continue to behave as before. 