### PR TITLE
update naming for application-update

### DIFF
--- a/data-lake/existing-tables-metadata.json
+++ b/data-lake/existing-tables-metadata.json
@@ -500,10 +500,10 @@
             },
             {
                 "database_name": "odw_standardised_db",
-                "table_name": "sb_application_update",
+                "table_name": "sb_applications_application_update",
                 "table_format": "delta",
                 "table_type": "EXTERNAL",
-                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_application_update"
+                "table_location": "abfss://odw-standardised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_applications_application_update"
             },
             {
                 "database_name": "odw_standardised_db",
@@ -1022,10 +1022,10 @@
             },
             {
                 "database_name": "odw_harmonised_db",
-                "table_name": "sb_application_update",
+                "table_name": "sb_applications_application_update",
                 "table_format": "delta",
                 "table_type": "EXTERNAL",
-                "table_location": "abfss://odw-harmonised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_application_update"
+                "table_location": "abfss://odw-harmonised@{DATA_LAKE_NAME}.dfs.core.windows.net/sb_applications_application_update"
             },
             {
                 "database_name": "odw_harmonised_db",

--- a/data-lake/orchestration/orchestration.json
+++ b/data-lake/orchestration/orchestration.json
@@ -2022,13 +2022,13 @@
       {
       "Source_ID": 161,
       "Source_Folder": "ServiceBus",
-      "Source_Frequency_Folder": "application-update",
-      "Source_Filename_Format": "application-update.csv",
-      "Source_Filename_Start": "application-update",
+      "Source_Frequency_Folder": "applications-application-update",
+      "Source_Filename_Format": "applications-application-update.csv",
+      "Source_Filename_Start": "applications-application-update",
       "Expected_Within_Weekdays": 1,
       "Standardised_Path": "",
-      "Standardised_Table_Name": "sb_application_update",
-      "Harmonised_Table_Name": "sb_application_update",
+      "Standardised_Table_Name": "sb_applications_application_update",
+      "Harmonised_Table_Name": "sb_applications_application_update",
       "Harmonised_Incremental_Key": "ApplicationUpdateID",
       "Entity_Primary_Key": "id",
       "odw_curated_table_creation_enabled": false

--- a/data-lake/orchestration/orchestration_service_bus.json
+++ b/data-lake/orchestration/orchestration_service_bus.json
@@ -182,11 +182,11 @@
       "has_horizon_dependency": false
     },
     {
-      "entity_name": "application-update",
-      "raw_entity_path": "ServiceBus/application-update/",
-      "standardised_table": "sb_application_update",
-      "sb_harmonised_table": "sb_application_update",
-      "harmonised_table": "application_update",
+      "entity_name": "applications-application-update",
+      "raw_entity_path": "ServiceBus/applications-application-update/",
+      "standardised_table": "sb_applications_application_update",
+      "sb_harmonised_table": "sb_applications_application_update",
+      "harmonised_table": "applications_application_update",
       "primary_key": "id",
       "harmonised_incremental_key": "ApplicationUpdateID",
       "watermark_column": "message_enqueued_time_utc",


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3444

The new entity definitions have been updated, we need to rename the crown dev service bus entities in line with conventions and to future-proof the eventual inclusion of s62a casework. 

As part of this, **application-update** entity has been renamed to **applications-application-update** along with the subscription and topic names (see ticket). This has been updated across all required repository's
 